### PR TITLE
fix: support for configuring listening port with env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ FROM nginx:alpine
 # Step 8: Copy the built React app from the previous build stage to the Nginx web directory
 COPY --from=build /app/build /usr/share/nginx/html
 
-# Step 9: Expose the port that the app will run on
-EXPOSE 80
+# Step 9: Copy nginx conf template so env variable PORT is used for listening port
+COPY --from=build /app/default.conf.template /etc/nginx/templates/
 
 # Step 10: Start Nginx server
 CMD ["nginx", "-g", "daemon off;"]

--- a/default.conf.template
+++ b/default.conf.template
@@ -1,0 +1,44 @@
+server {
+    listen       ${PORT};
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}
+


### PR DESCRIPTION
This PR makes it possible to configure listening port through an environment variable which is necessary for having it running in OSC.

We also discovered an issue deploying this repository where the repository name is to long for our system to handle (limitations in DNS and SSL common names). This is an issue we should address but for now I ask you to rename the repo to a shorter name and try again. Thanks!